### PR TITLE
Updated cipherscan to handle environmental error conditions better:

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -42,11 +42,6 @@ if [[ "$TIMEOUTOUTPUT" =~ BusyBox ]]; then
     TIMEOUTBIN="$TIMEOUTBIN -t"
 fi
 
-# use custom config file to enable GOST ciphers
-if [[ -e $(dirname $0)/openssl.cnf ]]; then
-    export OPENSSL_CONF="$(dirname $0)/openssl.cnf"
-fi
-
 # find a list of trusted CAs on the local system, or use the provided list
 if [ -z "$CACERTS" ]; then
     for f in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
@@ -1369,7 +1364,33 @@ if [ ! -x $OPENSSLBIN ]; then
     if [ "$OUTPUTFORMAT" == "terminal" ]; then
         echo "custom openssl not executable, falling back to system one from $OPENSSLBIN"
     fi
+else
+    tmp=$(echo "quit" | $OPENSSLBIN 2>&1)
+    if [ $? -ne 0 ]; then
+        OPENSSLBIN=$(which openssl)
+        if [ "$OUTPUTFORMAT" == "terminal" ]; then
+            echo "custom openssl fails to execute properly, falling back to system one from $OPENSSLBIN"
+            verbose "execution failure message: $tmp"
+        fi
+    fi
 fi
+
+# use custom config file to enable GOST ciphers if supported by whatever $OPENSSLBIN we ended up with
+if [[ -e $(dirname $0)/openssl.cnf ]]; then
+    tmp=$(OPENSSL_CONF="$(dirname $0)/openssl.cnf" $OPENSSLBIN s_client -help 2>&1 | grep :error:)
+    if [ -z "$tmp" ]; then
+        export OPENSSL_CONF="$(dirname $0)/openssl.cnf"
+        if [ "$OUTPUTFORMAT" == "terminal" ]; then
+            verbose "Enabling GOST ciphers via OPENSSL_CONF"
+        fi
+    else
+        if [ "$OUTPUTFORMAT" == "terminal" ]; then
+            echo "Not enabling GOST ciphers via OPENSSL_CONF due to errors: see verbose for details"
+            verbose "GOST config failed: $tmp"
+        fi
+    fi
+fi
+
 
 if [ $TEST_CURVES == "True" ]; then
     if [ ! -z "$($OPENSSLBIN s_client -curves 2>&1|head -1|grep 'unknown option')" ]; then


### PR DESCRIPTION
Running on a RHEL6 box two problems became apparent; this patch fixes them:
1. If bundled openssl is a bad binary (e.g. wrong glibc), use system openssl
2. Skip bundled openssl.cnf if it causes failures (e.g. openssl w/o GOST)

So, for 1:

If the bundled 'openssl' binary has the executable permission bit set but is not a valid executable
file for the system it's on, then currently it will fail.  In my example, the bundled openssl was compiled
against GLIBC 2.14, but RHEL 6 ships with GLIBC 2.12:

```
$ ./openssl
./openssl: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by ./openssl)
$
```

Other issues, such as running on a 32-bit platform, should cause equivalent errors.  The patch 
runs the bundled openssl with stdin "quit" and reverts to the system openssl if it doesn't exit
cleanly.

Before this patch, running cipherscan on RHEL6 resulted in an empty cipher report and 
`config not supported, connection failed` for all Fallbacks.

For 2:

If cipherscan falls back to the system openssl, and the system openssl does not support GOST,
then the use of the bundled openssl.cnf file will cause cipherscan to fail because s_client calls
error out:

```
$ OPENSSL_CONF=./openssl.cnf openssl s_client -help
Error configuring OpenSSL
140737353987912:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:187:filename(/usr/lib64/openssl/engines/libgost.so): /usr/lib64/openssl/engines/libgost.so: cannot open shared object file: No such file or directory
140737353987912:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
140737353987912:error:260B6084:engine routines:DYNAMIC_LOAD:dso not found:eng_dyn.c:450:
140737353987912:error:2606A074:engine routines:ENGINE_by_id:no such engine:eng_list.c:417:id=gost
140737353987912:error:260BC066:engine routines:INT_ENGINE_CONFIGURE:engine configuration error:eng_cnf.c:204:section=gost_section, name=default_algorithms, value=ALL
140737353987912:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=engines, value=engine_section, retcode=-1
$
```

To address this issue, the patch runs openssl using the bundled openssl.cnf and if any ":error:" is
found in the output, it will not use the bundled openssl.cnf.
