### PR TITLE
sort CA's by count, not name

### DIFF
--- a/top1m/parse_CAs.py
+++ b/top1m/parse_CAs.py
@@ -19,6 +19,7 @@ import sys
 from collections import defaultdict
 import os
 from OpenSSL import crypto
+from operator import itemgetter
 
 invocations = defaultdict(int)
 
@@ -321,12 +322,12 @@ for stat in sorted(effective_security):
 
 print("\nRoot CAs                                      Count     Percent")
 print("---------------------------------------------+---------+-------")
-for stat in sorted(root_CA):
-    percent = round(root_CA[stat] / total * 100, 4)
-    sys.stdout.write(stat.ljust(45)[0:45] + " " + str(root_CA[stat]).ljust(10) + str(percent).ljust(4) + "\n")
+for stat, val in sorted(root_CA.items(), key=itemgetter(1), reverse=True):
+    percent = round(val / total * 100, 4)
+    sys.stdout.write(stat.ljust(45)[0:45] + " " + str(val).ljust(10) + str(percent).ljust(4) + "\n")
 
 print("\nIntermediate CA                               Count     Percent")
 print("---------------------------------------------+---------+-------")
-for stat in sorted(intermediate_CA):
-    percent = round(intermediate_CA[stat] / total * 100, 4)
-    sys.stdout.write(stat.ljust(45)[0:45] + " " + str(intermediate_CA[stat]).ljust(10) + str(percent).ljust(4) + "\n")
+for stat, val in sorted(intermediate_CA.items(), key=itemgetter(1), reverse=True):
+    percent = round(val / total * 100, 4)
+    sys.stdout.write(stat.ljust(45)[0:45] + " " + str(val).ljust(10) + str(percent).ljust(4) + "\n")


### PR DESCRIPTION
since generally the interesting CAs are used by a large amount or a small amount of servers, sort them by count, not by name