### PR TITLE
fix -b (benchmark) output

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -837,8 +837,8 @@ display_results_in_terminal() {
         if [[ $different == "True" ]]; then
             echo "$result"|grep -v '(NONE)'
         else
-            # prints priority, ciphersuite, protocols and pfs
-            awk '!/(NONE)/{print $1 " " $2 " " $3 " " $10 " " $11}' <<<"$result"
+            # prints priority, ciphersuite, protocols, pfs and benchmark time (if any)
+            awk '!/(NONE)/{print $1 " " $2 " " $3 " " $10 " " $11 " " $13 }' <<<"$result"
         fi
     done|column -t
     echo

--- a/cipherscan
+++ b/cipherscan
@@ -659,6 +659,7 @@ test_cipher_on_target() {
             else
                 # resolve the openssl curve to the proper IANA name
                 current_curves="$(get_curve_name "$(echo $pfs|cut -d ',' -f2)")"
+                curves_ordering="unknown"
             fi
         fi
         result="$cipher $protocols $pubkey $sigalg $trusted $tickethint $ocspstaple $npn $pfs $current_curves $curves_ordering"
@@ -783,6 +784,8 @@ display_results_in_terminal() {
             npn="${cipher_data[7]}"
             if [[ $TEST_CURVES == "True" && -n ${cipher_data[10]} ]]; then
                 curvesordering="${cipher_data[10]}"
+            else
+                curvesordering="unknown"
             fi
         else
             if [[ "$pubkey" != "${cipher_data[2]}" ]]; then
@@ -803,11 +806,7 @@ display_results_in_terminal() {
             if [[ "$npn" != "${cipher_data[7]}" ]]; then
                 different=True
             fi
-            if [[ -z $curvesordering && -n "${cipher_data[10]}" ]]; then
-                curvesordering="${cipher_data[10]}"
-            fi
-            if [[ -n $curvesordering && "$curvesordering" != "${cipher_data[10]}" ]]; then
-                echo "CURVESORDERING"
+            if [[ "$TEST_CURVES" == "True" && "$curvesordering" != "${cipher_data[10]}" ]]; then
                 different=True
             fi
         fi


### PR DESCRIPTION
The benchmark column wasn't being rendered in the output, and just adding the field index to the `awk` invocation wouldn't be enough: the field index would change depending on whether `--curves` was enabled (because the `curve_ordering` column gets a value when it's turned on, but is blank when turned off).

The first patch ensures the curves_ordering column has a dummy value of `unknown` if `$TEST_CURVES` isn't `True`.
The second patch adds the benchmark microsecond data to the output.