### PR TITLE
Fixed symbolic link creation error and git output supression

### DIFF
--- a/cscan.sh
+++ b/cscan.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 pushd "$(dirname ${BASH_SOURCE[0]})" > /dev/null
 if [ ! -d ./tlslite ]; then
-    echo -e "\ntlslite-ng not found, downloading..."
+    echo -e "\n${BASH_SOURCE[0]}: tlslite-ng not found, downloading..."
     git clone --depth=1 https://github.com/tomato42/tlslite-ng.git .tlslite-ng
     ln -s .tlslite-ng/tlslite tlslite
 fi
 if [ ! -d ./ecdsa ]; then
-    echo -e "\npython-ecdsa not found, downloading..."
+    echo -e "\n${BASH_SOURCE[0]}: python-ecdsa not found, downloading..."
     git clone --depth=1 https://github.com/warner/python-ecdsa.git .python-ecdsa
     ln -s .python-ecdsa/src/ecdsa ecdsa
 fi

--- a/cscan.sh
+++ b/cscan.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 pushd "$(dirname ${BASH_SOURCE[0]})" > /dev/null
 if [ ! -d ./tlslite ]; then
-    git clone --depth=1 https://github.com/tomato42/tlslite-ng.git .tlslite-ng
+    git clone --depth=1 https://github.com/tomato42/tlslite-ng.git .tlslite-ng &>/dev/null
     ln -s .tlslite-ng/tlslite tlslite
 fi
 if [ ! -d ./ecdsa ]; then
-    git clone --depth=1 https://github.com/warner/python-ecdsa.git .python-ecdsa
-    ln -s .python-ecdsa/ecdsa ecdsa
+    git clone --depth=1 https://github.com/warner/python-ecdsa.git .python-ecdsa &>/dev/null
+    ln -s .python-ecdsa/src/ecdsa ecdsa
 fi
 
 # update the code if it is running in interactive terminal

--- a/cscan.sh
+++ b/cscan.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 pushd "$(dirname ${BASH_SOURCE[0]})" > /dev/null
 if [ ! -d ./tlslite ]; then
-    git clone --depth=1 https://github.com/tomato42/tlslite-ng.git .tlslite-ng &>/dev/null
+    echo -e "\ntlslite-ng not found, downloading..."
+    git clone --depth=1 https://github.com/tomato42/tlslite-ng.git .tlslite-ng
     ln -s .tlslite-ng/tlslite tlslite
 fi
 if [ ! -d ./ecdsa ]; then
-    git clone --depth=1 https://github.com/warner/python-ecdsa.git .python-ecdsa &>/dev/null
+    echo -e "\npython-ecdsa not found, downloading..."
+    git clone --depth=1 https://github.com/warner/python-ecdsa.git .python-ecdsa
     ln -s .python-ecdsa/src/ecdsa ecdsa
 fi
 


### PR DESCRIPTION
Added `&>/dev/null` on git commands to suppress their output
Fixed the symbolic link creation that pointed to non existent path. `ecdsa` folder moved to `src/ecdsa`